### PR TITLE
Catch the root URL

### DIFF
--- a/app/passthrough/views.py
+++ b/app/passthrough/views.py
@@ -14,8 +14,9 @@ from flask_login import current_user
 from . import passthrough_bp
 
 
+@passthrough_bp.route('/')
 @passthrough_bp.route('/<path:path>')
-def passthrough(path):
+def passthrough(path=""):
     if not current_user.is_authenticated:
         return redirect(url_for('auth.login', next=request.path))
     else:


### PR DESCRIPTION
I was getting 404s no matter what on the root URL until I added an extra URL pattern designed for it. Am I right that the existing one required something to follow the root slash to work?

This changed fixed my bug, but I suspect there might be a slicker way to do it yet with one pattern.