### PR TITLE
Prevent NoneType from getting into auth redirect as "next" value

### DIFF
--- a/app/passthrough/views.py
+++ b/app/passthrough/views.py
@@ -18,7 +18,7 @@ from . import passthrough_bp
 @passthrough_bp.route('/<path:path>')
 def passthrough(path=""):
     if not current_user.is_authenticated:
-        return redirect(url_for('auth.login', next=request.path))
+        return redirect(url_for('auth.login', next=request.path or ""))
     else:
         default_page = current_app.config.get('S3_INDEX_DOCUMENT')
         if default_page and (path == '' or path.endswith('/')):


### PR DESCRIPTION
If they get in there, it's not awesome.